### PR TITLE
Fix base url

### DIFF
--- a/Source/M3U8PlaylistModel.m
+++ b/Source/M3U8PlaylistModel.m
@@ -42,7 +42,7 @@
     
     self.originalURL = URL;
     
-    return [self initWithString:str baseURL:URL error:error];
+    return [self initWithString:str baseURL:[URL URLByDeletingLastPathComponent] error:error];
 }
 
 - (id)initWithString:(NSString *)string baseURL:(NSURL *)baseURL error:(NSError **)error {

--- a/Source/M3U8PlaylistModel.m
+++ b/Source/M3U8PlaylistModel.m
@@ -42,7 +42,7 @@
     
     self.originalURL = URL;
     
-    return [self initWithString:str baseURL:URL.realBaseURL error:error];
+    return [self initWithString:str baseURL:URL error:error];
 }
 
 - (id)initWithString:(NSString *)string baseURL:(NSURL *)baseURL error:(NSError **)error {

--- a/Source/Master Playlist/M3U8MasterPlaylist.m
+++ b/Source/Master Playlist/M3U8MasterPlaylist.m
@@ -49,7 +49,7 @@
     self.originalURL = URL;
     
     NSString *string = [NSString stringWithContentsOfURL:URL encoding:NSUTF8StringEncoding error:error];
-    return [self initWithContent:string baseURL:URL];
+    return [self initWithContent:string baseURL:[URL URLByDeletingLastPathComponent]];
 }
 
 - (void)parseMasterPlaylist {

--- a/Source/Master Playlist/M3U8MasterPlaylist.m
+++ b/Source/Master Playlist/M3U8MasterPlaylist.m
@@ -49,7 +49,7 @@
     self.originalURL = URL;
     
     NSString *string = [NSString stringWithContentsOfURL:URL encoding:NSUTF8StringEncoding error:error];
-    return [self initWithContent:string baseURL:URL.realBaseURL];
+    return [self initWithContent:string baseURL:URL];
 }
 
 - (void)parseMasterPlaylist {

--- a/Source/Media Playlist/M3U8MediaPlaylist.m
+++ b/Source/Media Playlist/M3U8MediaPlaylist.m
@@ -48,7 +48,7 @@
     
     NSString *string = [[NSString alloc] initWithContentsOfURL:URL encoding:NSUTF8StringEncoding error:error];
     
-    return [self initWithContent:string type:type baseURL:URL];
+    return [self initWithContent:string type:type baseURL:[URL URLByDeletingLastPathComponent]];
 }
 
 - (NSArray *)allSegmentURLs {

--- a/Source/Media Playlist/M3U8MediaPlaylist.m
+++ b/Source/Media Playlist/M3U8MediaPlaylist.m
@@ -48,7 +48,7 @@
     
     NSString *string = [[NSString alloc] initWithContentsOfURL:URL encoding:NSUTF8StringEncoding error:error];
     
-    return [self initWithContent:string type:type baseURL:URL.realBaseURL];
+    return [self initWithContent:string type:type baseURL:URL];
 }
 
 - (NSArray *)allSegmentURLs {


### PR DESCRIPTION
Jde o to, kdyz mas nejakou cestu na url, napriklad: `https://vod-prep-prot.viaplay.cdn.cra.cz/vod_Balt_FP/_definst_/0035/0984/eng-ao-sd1-sd2-sd3-sd4-hd1-hd2-axinom-6CcCPxs5.smil/chunklist_b3334144.m3u8`. Takze kdy vezmes ten url, a zavolas `url.realBaseURL`, ten ti generuje jenom `https://vod-prep-prot.viaplay.cdn.cra.cz`. A potom pozdeji pouzivas ten url a zavolas `https://vod-prep-prot.viaplay.cdn.cra.cz/chunklist_b3334144.m3u8`, tak je to spatny, chybi tam cesty.