### PR TITLE
fix out of bounds when calling substringWithRange in parseMediaPlaylist

### DIFF
--- a/Source/Media Playlist/M3U8MediaPlaylist.m
+++ b/Source/Media Playlist/M3U8MediaPlaylist.m
@@ -69,7 +69,8 @@
     self.segmentList = [[M3U8SegmentInfoList alloc] init];
     
     NSRange segmentRange = [self.originalText rangeOfString:M3U8_EXTINF];
-    NSString *remainingSegments = self.originalText;
+    NSString *remainingSegments = [self.originalText substringFromIndex:segmentRange.location];
+    segmentRange = [remainingSegments rangeOfString:M3U8_EXTINF];
     
     while (NSNotFound != segmentRange.location) {
         NSMutableDictionary *params = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Jde o to, kdy dostanes neco takovyho
 ```#EXTM3U
#EXT-X-VERSION:5
#EXT-X-TARGETDURATION:10
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-KEY:METHOD=SAMPLE-AES,URI="skd://53044b22-61a3-e5a5-0e01-fb55e7a1e4b2",KEYFORMAT="com.apple.streamingkeydelivery",KEYFORMATVERSIONS="1"
#EXTINF:10.0,
media_b40960_ao_0.aac
#EXTINF:10.0,
media_b40960_ao_1.aac
#EXTINF:10.0,
media_b40960_ao_2.aac
#EXTINF:10.0 
```

v metode **parseMediaPlaylist**,  na radce **71 (NSRange segmentRange = [self.originalText rangeOfString:M3U8_EXTINF];)** a na radce **NSRange commaRange = [remainingSegments rangeOfString:@","];**. Potom nasledujici radce **NSRange valueRange = NSMakeRange(segmentRange.location + 8, commaRange.location - (segmentRange.location + 8));** Problem je to **commaRange.location je mensi nez (segmentRange.location + 8) **, z toho vnikne nejaky random cislo, ktery je vetsi nez** remainingSegments.length**.